### PR TITLE
[Enhancement] Reduce monitor CPU usage

### DIFF
--- a/orchestrator/config/config_files/health_check_monitor.yaml
+++ b/orchestrator/config/config_files/health_check_monitor.yaml
@@ -1,3 +1,5 @@
 ip: '127.0.0.1'
 port: "9092"
 liveness_probe: 2
+health_check_interval: 1
+liveness_tracking_interval: 2

--- a/orchestrator/config/types.go
+++ b/orchestrator/config/types.go
@@ -7,7 +7,9 @@ type ConfigurationManager struct {
 
 // HealthCheckMonitorConfig Houses the configurations of the healthcheck monitor
 type HealthCheckMonitorConfig struct {
-	IP            string `yaml:"ip"`             //IP of the monitor
-	Port          string `yaml:"port"`           //Port on which it receives healthchecks
-	LivenessProbe int    `yaml:"liveness_probe"` //A duration (in secs) after which a process is considered dead
+	IP                       string `yaml:"ip"`                         //IP of the monitor
+	Port                     string `yaml:"port"`                       //Port on which it receives healthchecks
+	LivenessProbe            int    `yaml:"liveness_probe"`             //A duration (in secs) after which a process is considered dead
+	HealthCheckInterval      int    `yaml:"health_check_interval"`      //The frequency of polling for health checks
+	LivenessTrackingInterval int    `yaml:"liveness_tracking_interval"` //The frequency for checking dead processes
 }

--- a/orchestrator/health/types.go
+++ b/orchestrator/health/types.go
@@ -10,13 +10,15 @@ import (
 
 // Monitor Represents the health check monitor object
 type Monitor struct {
-	ip                string                  //IP of the monitor
-	port              string                  //Port on which the monitor recieves messages from monitored processes
-	connectionHandler tcp.Connection          //A TCP socket used for listening to topic
-	processList       map[int]process.Process //Records when was each process last seen
-	processListMutex  *sync.Mutex             //Used to insure thread safety while accessing the process list
-	livenessProbe     time.Duration           //The max allowed delay after which a process is considered dead
-	activeRoutines    int                     //The number of active routines the monitor executes
-	wg                sync.WaitGroup          //Used to wait on fired goroutines
-	shutdown          chan bool               //Used to handle shutdown signals
+	ip                       string                  //IP of the monitor
+	port                     string                  //Port on which the monitor recieves messages from monitored processes
+	connectionHandler        tcp.Connection          //A TCP socket used for listening to topic
+	processList              map[int]process.Process //Records when was each process last seen
+	processListMutex         *sync.Mutex             //Used to insure thread safety while accessing the process list
+	livenessProbe            time.Duration           //The max allowed delay after which a process is considered dead
+	healthCheckInterval      time.Duration           //The frequency at which the monitor polls for healthchecks
+	livenessTrackingInterval time.Duration           //The frequency at which the monitor checks dead processes
+	activeRoutines           int                     //The number of active routines the monitor executes
+	wg                       sync.WaitGroup          //Used to wait on fired goroutines
+	shutdown                 chan bool               //Used to handle shutdown signals
 }


### PR DESCRIPTION
- We noticed that the monitor uses too much CPU, almost `51%` of the containers CPU.
- This PR reduces the frequency at which the monitor polls for health checks and reaps dead processes.
- Now the monitor uses around `1%` of the container's CPU.
- Also the container doesn't use that much CPU from the host machine.