### PR TITLE
[Feature][Orchestrator] Pass args to executor processes

### DIFF
--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -5,4 +5,9 @@ build: install
 	GO114MODULE=on go build -o ingestion-engine.bin .
 
 run: build
-	./ingestion-engine.bin
+	./ingestion-engine.bin \
+	-video-path=$(video-path) \
+	-model-path=$(model-path) \
+	-model-config-path=$(model-config-path) \
+	-start-idx=$(start-idx) \
+	-frame-count=$(frame-count)

--- a/orchestrator/config/config_files/processes_manager.yaml
+++ b/orchestrator/config/config_files/processes_manager.yaml
@@ -3,3 +3,9 @@ process_groups:
     replicas: 3
     command: "/app/venv/bin/python3"
     script: "/app/executor/main.py"
+    arg_prefix: "-"
+    arg_assign: "="
+    args:
+      - flag: video-path
+      - flag: model-path
+      - flag: model-config-path

--- a/orchestrator/config/processes_manager.go
+++ b/orchestrator/config/processes_manager.go
@@ -5,12 +5,21 @@ type ProcessesManagerConfig struct {
 	ProcessGroups []ProcessGroupConfig `yaml:"process_groups"` //Represents the process groups the manager is managing
 }
 
+// ProcessArg Represents a command line argument to a process
+type ProcessArg struct {
+	Flag  string `yaml:"flag"`  //Flag used for named args
+	Value string `yaml:"value"` //Optional value for the arg. If not provided, it fallsback to gloabl params
+}
+
 // ProcessGroupConfig Houses the configurations of a specific process group
 type ProcessGroupConfig struct {
-	Name     string `yaml:"name"`     //The name of the process group
-	Replicas int    `yaml:"replicas"` //Specifies how many process replicas in the process group
-	Command  string `yaml:"command"`  //Speciifes the command used to run the script
-	Script   string `yaml:"script"`   //Specifies the actual script to be run for all processes in the group
+	Name      string       `yaml:"name"`       //The name of the process group
+	Replicas  int          `yaml:"replicas"`   //Specifies how many process replicas in the process group
+	Command   string       `yaml:"command"`    //Speciifes the command used to run the script
+	Script    string       `yaml:"script"`     //Specifies the actual script to be run for all processes in the group
+	ArgPrefix string       `yaml:"arg_prefix"` //Used to prefix the arg flag, i.e. -flag or --flag
+	ArgAssign string       `yaml:"arg_assign"` //Used to assign values to the arg flag, i.e. flag=val or flag val
+	Args      []ProcessArg `yaml:"args"`       //Array of arguments to be passed to the process
 }
 
 // ProcessManagerConfig A function to return the processes manager config

--- a/orchestrator/process/process.go
+++ b/orchestrator/process/process.go
@@ -10,7 +10,7 @@ import (
 
 // execute A function to execute a staged process
 func (processObj *process) execute() (*exec.Cmd, error) {
-	cmd := exec.Command(processObj.Group.Command, processObj.Group.Script)
+	cmd := exec.Command(processObj.Group.Command, processObj.Group.Args...)
 
 	err := cmd.Start()
 	if errors.IsError(err) {
@@ -38,12 +38,11 @@ func newProcess(group processGroup) process {
 }
 
 // newGroup A function to create a new process group instance
-func newProcessGroup(name string, replicas int, command string, script string, args []string) processGroup {
+func newProcessGroup(name string, replicas int, command string, args []string) processGroup {
 	return processGroup{
 		Name:     name,
 		Replicas: replicas,
 		Command:  command,
-		Script:   script,
 		Args:     args,
 	}
 }

--- a/orchestrator/process/process.go
+++ b/orchestrator/process/process.go
@@ -38,11 +38,12 @@ func newProcess(group processGroup) process {
 }
 
 // newGroup A function to create a new process group instance
-func newProcessGroup(name string, replicas int, command string, script string) processGroup {
+func newProcessGroup(name string, replicas int, command string, script string, args []string) processGroup {
 	return processGroup{
 		Name:     name,
 		Replicas: replicas,
 		Command:  command,
 		Script:   script,
+		Args:     args,
 	}
 }

--- a/orchestrator/process/types.go
+++ b/orchestrator/process/types.go
@@ -40,6 +40,5 @@ type processGroup struct {
 	Name     string   //The name for the process group
 	Replicas int      //The number of replicas
 	Command  string   //Path to the process group command
-	Script   string   //Path to the process group script
 	Args     []string //Array of arguments to be passed to the process
 }

--- a/orchestrator/process/types.go
+++ b/orchestrator/process/types.go
@@ -37,8 +37,9 @@ type process struct {
 
 // processGroup Represents a group of similar processes
 type processGroup struct {
-	Name     string //The name for the process group
-	Replicas int    //The number of replicas
-	Command  string //Path to the process group command
-	Script   string //Path to the process group script
+	Name     string   //The name for the process group
+	Replicas int      //The number of replicas
+	Command  string   //Path to the process group command
+	Script   string   //Path to the process group script
+	Args     []string //Array of arguments to be passed to the process
 }

--- a/orchestrator/process/utils.go
+++ b/orchestrator/process/utils.go
@@ -25,8 +25,8 @@ func buildStagedProcessesList(managerConfig config.ProcessesManagerConfig) []pro
 	var stagedProcessesList []process
 
 	for _, group := range managerConfig.ProcessGroups {
-		groupArgs := getProcessGroupArgs(group.ArgPrefix, group.ArgAssign, group.Args)
-		groupInstance := newProcessGroup(group.Name, group.Replicas, group.Command, group.Script, groupArgs)
+		groupArgs := getProcessGroupArgs(group.Script, group.ArgPrefix, group.ArgAssign, group.Args)
+		groupInstance := newProcessGroup(group.Name, group.Replicas, group.Command, groupArgs)
 
 		for i := 0; i < group.Replicas; i++ {
 			stagedProcessesList = append(stagedProcessesList, newProcess(groupInstance))
@@ -37,8 +37,8 @@ func buildStagedProcessesList(managerConfig config.ProcessesManagerConfig) []pro
 }
 
 // getProcessGroupArgs A function to construct process arguments from config
-func getProcessGroupArgs(argsPrefix string, argsAssign string, args []config.ProcessArg) []string {
-	var groupArgs []string
+func getProcessGroupArgs(script string, argsPrefix string, argsAssign string, args []config.ProcessArg) []string {
+	groupArgs := []string{script}
 
 	for _, arg := range args {
 		value := arg.Value

--- a/orchestrator/process/utils.go
+++ b/orchestrator/process/utils.go
@@ -2,8 +2,10 @@ package process
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/SayedAlesawy/Videra-Ingestion/orchestrator/config"
+	"github.com/SayedAlesawy/Videra-Ingestion/orchestrator/utils/params"
 )
 
 // ParseUtilization A function to parse the process util stats recieved in healthchecks
@@ -23,7 +25,8 @@ func buildStagedProcessesList(managerConfig config.ProcessesManagerConfig) []pro
 	var stagedProcessesList []process
 
 	for _, group := range managerConfig.ProcessGroups {
-		groupInstance := newProcessGroup(group.Name, group.Replicas, group.Command, group.Script)
+		groupArgs := getProcessGroupArgs(group.ArgPrefix, group.ArgAssign, group.Args)
+		groupInstance := newProcessGroup(group.Name, group.Replicas, group.Command, group.Script, groupArgs)
 
 		for i := 0; i < group.Replicas; i++ {
 			stagedProcessesList = append(stagedProcessesList, newProcess(groupInstance))
@@ -31,4 +34,20 @@ func buildStagedProcessesList(managerConfig config.ProcessesManagerConfig) []pro
 	}
 
 	return stagedProcessesList
+}
+
+// getProcessGroupArgs A function to construct process arguments from config
+func getProcessGroupArgs(argsPrefix string, argsAssign string, args []config.ProcessArg) []string {
+	var groupArgs []string
+
+	for _, arg := range args {
+		value := arg.Value
+		if value == "" {
+			value = params.OrchestratorParamsInstance().ArgsMap[arg.Flag].(string)
+		}
+
+		groupArgs = append(groupArgs, fmt.Sprintf("%s%s%s%s", argsPrefix, arg.Flag, argsAssign, value))
+	}
+
+	return groupArgs
 }

--- a/orchestrator/utils/params/params.go
+++ b/orchestrator/utils/params/params.go
@@ -11,10 +11,20 @@ import (
 // logPrefix Used for hierarchical logging
 var logPrefix = "[Params-Manager]"
 
+// Default values
 const (
-	defaultStringValue string = ""
-	defaultIntValue    int    = -1
-	defaultLogIntValue int64  = -1
+	defaultStringValue  string = ""
+	defaultIntValue     int    = -1
+	defaultLongIntValue int64  = -1
+)
+
+// Params flag names
+const (
+	videopathFlag       = "video-path"
+	modelPathFlag       = "model-path"
+	modelConfigPathFlag = "model-config-path"
+	startIdxFlag        = "start-idx"
+	frameCountFlag      = "frame-count"
 )
 
 // orchestratorParamsOnce Used to garauntee thread safety for singleton instances
@@ -26,26 +36,40 @@ var orchestratorParamsInstance *OrchestratorParams
 // OrchestratorParamsInstance A function to return the orchestrator params singleton instance
 func OrchestratorParamsInstance() *OrchestratorParams {
 	orchestratorParamsOnce.Do(func() {
-		videoPath := flag.String("video-path", "", "path to the video to be processed")
-		modelPath := flag.String("model-path", "", "path to the model to be applied")
-		configPath := flag.String("model-config-path", "", "path to the model config to be applied")
-		startIdx := flag.Int64("start-idx", -1, "starting index from which to process video at path")
-		frameCount := flag.Int64("frame-count", -1, "number of frames to process starting from start-idx")
+		videoPath := flag.String(videopathFlag, "", "path to the video to be processed")
+		modelPath := flag.String(modelPathFlag, "", "path to the model to be applied")
+		configPath := flag.String(modelConfigPathFlag, "", "path to the model config to be applied")
+		startIdx := flag.Int64(startIdxFlag, -1, "starting index from which to process video at path")
+		frameCount := flag.Int64(frameCountFlag, -1, "number of frames to process starting from start-idx")
 
 		flag.Parse()
 
 		orchestratorParams := OrchestratorParams{
-			VideoPath:       validatePath(validate("video-path", *videoPath).(string)),
-			ModelPath:       validatePath(validate("model-path", *modelPath).(string)),
-			ModelConfigPath: validatePath(validate("model-config-path", *configPath).(string)),
-			StartIdx:        validate("start-idx", *startIdx).(int64),
-			FrameCount:      validate("frame-count", *frameCount).(int64),
+			VideoPath:       validatePath(validate(videopathFlag, *videoPath).(string)),
+			ModelPath:       validatePath(validate(modelPathFlag, *modelPath).(string)),
+			ModelConfigPath: validatePath(validate(modelConfigPathFlag, *configPath).(string)),
+			StartIdx:        validate(startIdxFlag, *startIdx).(int64),
+			FrameCount:      validate(frameCountFlag, *frameCount).(int64),
 		}
+
+		orchestratorParams.mapParams()
 
 		orchestratorParamsInstance = &orchestratorParams
 	})
 
 	return orchestratorParamsInstance
+}
+
+func (orchOarams *OrchestratorParams) mapParams() {
+	paramsMap := make(map[string]interface{})
+
+	paramsMap[videopathFlag] = orchOarams.VideoPath
+	paramsMap[modelPathFlag] = orchOarams.ModelPath
+	paramsMap[modelConfigPathFlag] = orchOarams.ModelConfigPath
+	paramsMap[startIdxFlag] = orchOarams.StartIdx
+	paramsMap[frameCountFlag] = orchOarams.FrameCount
+
+	orchOarams.ArgsMap = paramsMap
 }
 
 // validate A function to validate required params
@@ -58,7 +82,7 @@ func validate(param string, value interface{}) interface{} {
 	case int:
 		hasDefaultVal = isDefault(value.(int), defaultIntValue)
 	case int64:
-		hasDefaultVal = isDefault(value.(int64), defaultLogIntValue)
+		hasDefaultVal = isDefault(value.(int64), defaultLongIntValue)
 	default:
 		return false
 	}

--- a/orchestrator/utils/params/params.go
+++ b/orchestrator/utils/params/params.go
@@ -60,16 +60,16 @@ func OrchestratorParamsInstance() *OrchestratorParams {
 	return orchestratorParamsInstance
 }
 
-func (orchOarams *OrchestratorParams) mapParams() {
+func (orchParams *OrchestratorParams) mapParams() {
 	paramsMap := make(map[string]interface{})
 
-	paramsMap[videopathFlag] = orchOarams.VideoPath
-	paramsMap[modelPathFlag] = orchOarams.ModelPath
-	paramsMap[modelConfigPathFlag] = orchOarams.ModelConfigPath
-	paramsMap[startIdxFlag] = orchOarams.StartIdx
-	paramsMap[frameCountFlag] = orchOarams.FrameCount
+	paramsMap[videopathFlag] = orchParams.VideoPath
+	paramsMap[modelPathFlag] = orchParams.ModelPath
+	paramsMap[modelConfigPathFlag] = orchParams.ModelConfigPath
+	paramsMap[startIdxFlag] = orchParams.StartIdx
+	paramsMap[frameCountFlag] = orchParams.FrameCount
 
-	orchOarams.ArgsMap = paramsMap
+	orchParams.ArgsMap = paramsMap
 }
 
 // validate A function to validate required params

--- a/orchestrator/utils/params/types.go
+++ b/orchestrator/utils/params/types.go
@@ -2,9 +2,10 @@ package params
 
 // OrchestratorParams Houses the command line params passed to the orchestrator
 type OrchestratorParams struct {
-	VideoPath       string //Path of the video chunk to be processed
-	ModelPath       string //Path of the user CV model to be applied
-	ModelConfigPath string //Path of the user CV model config to be applied
-	StartIdx        int64  //Start index from which processing would start
-	FrameCount      int64  //Frame count to be processes
+	VideoPath       string                 //Path of the video chunk to be processed
+	ModelPath       string                 //Path of the user CV model to be applied
+	ModelConfigPath string                 //Path of the user CV model config to be applied
+	StartIdx        int64                  //Start index from which processing would start
+	FrameCount      int64                  //Frame count to be processes
+	ArgsMap         map[string]interface{} //Houses all params in a key-value format
 }


### PR DESCRIPTION
This PR adds the following:
- Ability to define process group args in the process config file.
- Spawning process with specified args.
- Fallback to global arguments in case no value for argument was specified.